### PR TITLE
Implement a node command controller

### DIFF
--- a/Classes/Command/NodeCommandController.php
+++ b/Classes/Command/NodeCommandController.php
@@ -1,0 +1,78 @@
+<?php
+
+
+namespace CRON\NeosCliTools\Command;
+
+
+use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
+use Neos\Flow\Annotations as Flow;
+
+
+class NodeCommandController extends \Neos\Flow\Cli\CommandController
+{
+    /**
+     * @Flow\Inject
+     * @var \CRON\NeosCliTools\Service\CRService
+     */
+    protected $cr;
+
+    /**
+     * Print a debug output of the given node
+     *
+     * @param NodeInterface $node
+     */
+    protected function printDebugNode(NodeInterface $node) {
+        $data = [
+            'identifier' => $node->getIdentifier(),
+            'name' => $node->getName(),
+            'type' => $node->getNodeType()->getName(),
+            'isHidden' => $node->isHidden(),
+            'properties' => $node->getProperties(),
+        ];
+
+        $this->outputLine(json_encode($data));
+    }
+
+
+    protected function dump(NodeInterface $node) {
+        $this->printDebugNode($node);
+    }
+
+    /**
+     * Dump the content of a specific node
+     *
+     * @param string $url URL of the node, e.g. '/news'
+     * @param string $path full path of the specific node, e.g. '/sites/mysite/node..'
+     * @param string $identifier Node identifier, e.g. 30fb88f3-36da-49c4-9dee-2a16dd01bf78
+     * @param string $workspace workspace to use, e.g. 'user-admin', defaults to 'live'
+     */
+    public function dumpCommand($url = null, $path = null, $identifier = null, $workspace = 'live') {
+
+        try {
+            $this->cr->setup($workspace);
+
+            /** @var NodeInterface $node */
+            $node = null;
+
+            if ($url !== null) {
+                $node = $this->cr->getNodeForURL($url);
+            } else if ($path !== null) {
+                $node = $this->cr->getNodeForPath($path);
+            } else if ($identifier !== null) {
+                $node = $this->cr->context->getNodeByIdentifier($identifier);
+            } else {
+                throw new \Exception(sprintf('At least --url, --path or --identifier must be supplied'));
+            }
+
+            if ($node === null) {
+                throw new \Exception('not found');
+            }
+
+            $this->dump($node);
+
+        } catch (\Exception $e) {
+            $this->outputLine('ERROR: %s', [$e->getMessage()]);
+        }
+    }
+
+}


### PR DESCRIPTION
This implements a new "node command controller" to do things like:

```
$ flow help node:dump
Dump the content of a specific node
COMMAND:
  cron.neosclitools:node:dump
USAGE:
  ./flow node:dump [<options>]
OPTIONS:
  --url                URL of the node, e.g. '/news'
  --path               full path of the specific node, e.g.
                       '/sites/mysite/node..'
  --identifier         Node identifier, e.g.
                       30fb88f3-36da-49c4-9dee-2a16dd01bf78
  --workspace          workspace to use, e.g. 'user-admin', defaults to 'live'
```

And so to dump the content of a specific node as JSON.