### PR TITLE
Neos ^5.0 compatibility

### DIFF
--- a/Classes/Command/ContentCommandController.php
+++ b/Classes/Command/ContentCommandController.php
@@ -4,6 +4,7 @@ namespace CRON\NeosCliTools\Command;
 
 use CRON\NeosCliTools\Service\CRService;
 use Exception;
+use Neos\ContentRepository\Domain\NodeAggregate\NodeName;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 
@@ -26,13 +27,13 @@ class ContentCommandController extends CommandController
         try {
             $this->cr->setup($workspace);
             $page = $this->cr->getNodeForURL($url);
-            $collectionNode = $page->getNode($collection);
+            $collectionNode = $page->findNamedChildNode(NodeName::fromString($collection));
 
             if ($collectionNode === null) {
                 throw new Exception(sprintf('page has no collection node named "%s"', $collection));
             }
 
-            foreach ($collectionNode->getChildNodes() as $childNode) {
+            foreach ($collectionNode->findChildNodes() as $childNode) {
                 $this->outputLine($childNode);
             }
 
@@ -70,7 +71,7 @@ class ContentCommandController extends CommandController
             $page = $this->cr->getNodeForURL($url);
 
             // Check if the content collection exists. If not, create it
-            $collectionNode = $page->getNode($collection);
+            $collectionNode = $page->findNamedChildNode(NodeName::fromString($collection));
 
             if (!$collectionNode) {
                 $this->outputLine(sprintf('Could not find collection \'%s\', creating... .', $collection));
@@ -84,7 +85,7 @@ class ContentCommandController extends CommandController
                 $componentPathSegments = explode('/', trim($componentPath, '/'));
 
                 foreach ($componentPathSegments as $componentPathSegment) {
-                    $nextSegmentNode = $segmentNode->getNode($componentPathSegment);
+                    $nextSegmentNode = $segmentNode->findNamedChildNode(NodeName::fromString($componentPathSegment));
                     if (!$nextSegmentNode) {
                         $nextSegmentNode = $segmentNode->createNode($componentPathSegment);
                     }
@@ -92,7 +93,7 @@ class ContentCommandController extends CommandController
                 }
             }
 
-            $existingNode = $segmentNode->getNode($name);
+            $existingNode = $segmentNode->findNamedChildNode(NodeName::fromString($name));
 
             if ($overwriteExisting && $existingNode) {
                 $contentNode = $existingNode;

--- a/Classes/Command/ContentCommandController.php
+++ b/Classes/Command/ContentCommandController.php
@@ -1,22 +1,17 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: remuslazar
- * Date: 2019-01-30
- * Time: 16:06
- */
 
 namespace CRON\NeosCliTools\Command;
 
-use /** @noinspection PhpUnusedAliasInspection */
-    Neos\Flow\Annotations as Flow;
+use CRON\NeosCliTools\Service\CRService;
+use Exception;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Cli\CommandController;
 
-class ContentCommandController extends \Neos\Flow\Cli\CommandController
+class ContentCommandController extends CommandController
 {
-
     /**
      * @Flow\Inject
-     * @var \CRON\NeosCliTools\Service\CRService
+     * @var CRService
      */
     protected $cr;
 
@@ -26,7 +21,7 @@ class ContentCommandController extends \Neos\Flow\Cli\CommandController
      * @param string $collection collection node name, defaults to 'main'
      * @param string $workspace workspace to use, e.g. 'user-admin', defaults to 'live'
      */
-    public function listCommand($url, $collection = 'main', $workspace = 'live') {
+    public function listCommand(string $url, string $collection = 'main', string $workspace = 'live') {
 
         try {
             $this->cr->setup($workspace);
@@ -34,14 +29,14 @@ class ContentCommandController extends \Neos\Flow\Cli\CommandController
             $collectionNode = $page->getNode($collection);
 
             if ($collectionNode === null) {
-                throw new \Exception(sprintf('page has no collection node named "%s"', $collection));
+                throw new Exception(sprintf('page has no collection node named "%s"', $collection));
             }
 
             foreach ($collectionNode->getChildNodes() as $childNode) {
                 $this->outputLine($childNode);
             }
 
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->outputLine('ERROR: %s', [$e->getMessage()]);
         }
     }
@@ -50,23 +45,23 @@ class ContentCommandController extends \Neos\Flow\Cli\CommandController
      * Creates a new content element
      *
      * @param string $url page URL of the page where the content element should be inserted
-     * @param string $properties node properties, as JSON, e.g. '{"myAttribute":"My Fancy Value"}'
+     * @param string|null $properties node properties, as JSON, e.g. '{"myAttribute":"My Fancy Value"}'
      * @param string $type node type, defaults to Neos.Neos.NodeTypes:Text
      * @param string $collection collection name, defaults to 'main'
-     * @param string $name name of the node, leave empty to get a random uuid like name
+     * @param string|null $name name of the node, leave empty to get a random uuid like name
      * @param string $workspace workspace to use, e.g. 'user-admin', defaults to 'live'
-     * @param string $componentPath path of the component within the content collection where the nested content element should be inserted
+     * @param string|null $componentPath path of the component within the content collection where the nested content element should be inserted
      * @param boolean $overwriteExisting whether to overwrite an existing node for that path instead of creating a new one with path segment "node-..."
      */
     public function createCommand(
-        $url,
-        $properties = null,
-        $type = 'Neos.Neos.NodeTypes:Text',
-        $collection = 'main',
-        $name = null,
-        $workspace = 'live',
-        $componentPath = null,
-        $overwriteExisting = false
+        string $url,
+        string $properties = null,
+        string $type = 'Neos.Neos.NodeTypes:Text',
+        string $collection = 'main',
+        string $name = null,
+        string $workspace = 'live',
+        string $componentPath = null,
+        bool $overwriteExisting = false
     ) {
         try {
             $this->cr->setup($workspace);
@@ -110,9 +105,8 @@ class ContentCommandController extends \Neos\Flow\Cli\CommandController
             if ($properties) {
                 $this->cr->setNodeProperties($contentNode, $properties);
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->outputLine('ERROR: %s', [$e->getMessage()]);
         }
-
     }
 }

--- a/Classes/Command/PageCommandController.php
+++ b/Classes/Command/PageCommandController.php
@@ -4,6 +4,7 @@ namespace CRON\NeosCliTools\Command;
 
 use CRON\NeosCliTools\Service\CRService;
 use Exception;
+use Neos\ContentRepository\Domain\NodeAggregate\NodeName;
 use Neos\Flow\Annotations as Flow;
 use CRON\NeosCliTools\Utility\NeosDocumentTreePrinter;
 use CRON\NeosCliTools\Utility\NeosDocumentWalker;
@@ -174,7 +175,7 @@ class PageCommandController extends CommandController
             $nodeType = $this->cr->getNodeType($type);
             $parentNode = $this->cr->getNodeForURL($parentUrl);
 
-            $existingNode = $parentNode->getNode($name);
+            $existingNode = $parentNode->findNamedChildNode(NodeName::fromString($name));
 
             if ($overwriteExisting && $existingNode) {
                 $node = $existingNode;

--- a/Classes/Command/PageCommandController.php
+++ b/Classes/Command/PageCommandController.php
@@ -5,11 +5,11 @@ namespace CRON\NeosCliTools\Command;
 use CRON\NeosCliTools\Service\CRService;
 use Exception;
 use Neos\ContentRepository\Domain\NodeAggregate\NodeName;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\Flow\Annotations as Flow;
 use CRON\NeosCliTools\Utility\NeosDocumentTreePrinter;
 use CRON\NeosCliTools\Utility\NeosDocumentWalker;
 use Neos\Flow\Cli\CommandController;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Flow\Cli\Exception\StopCommandException;
 use Neos\Flow\Mvc\Exception\StopActionException;
 
@@ -105,14 +105,13 @@ class PageCommandController extends CommandController
             }
             $walker = new NeosDocumentWalker($rootNode);
 
-            /** @var NodeInterface[] $nodesToDelete */
             $nodesToDelete = $walker->getNodes($limit);
 
             foreach ($nodesToDelete as $nodeToDelete) {
                 $nodeToDelete->remove();
             }
 
-            $this->output->outputTable(array_map( function(NodeInterface $node) { return [$node]; }, $nodesToDelete),
+            $this->output->outputTable(array_map(function(TraversableNodeInterface $node) { return [$node]; }, $nodesToDelete),
                 ['Deleted Pages']);
             $this->quit(count($nodesToDelete) > 0 ? 0 : 1);
 

--- a/Classes/Command/PageCommandController.php
+++ b/Classes/Command/PageCommandController.php
@@ -1,20 +1,16 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: remuslazar
- * Date: 02.05.18
- * Time: 18:58
- */
 
 namespace CRON\NeosCliTools\Command;
 
-use /** @noinspection PhpUnusedAliasInspection */
-    Neos\Flow\Annotations as Flow;
-
+use CRON\NeosCliTools\Service\CRService;
+use Exception;
+use Neos\Flow\Annotations as Flow;
 use CRON\NeosCliTools\Utility\NeosDocumentTreePrinter;
 use CRON\NeosCliTools\Utility\NeosDocumentWalker;
 use Neos\Flow\Cli\CommandController;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Flow\Cli\Exception\StopCommandException;
+use Neos\Flow\Mvc\Exception\StopActionException;
 
 /**
  * Class PageCommandController
@@ -31,10 +27,9 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
  */
 class PageCommandController extends CommandController
 {
-
     /**
      * @Flow\Inject
-     * @var \CRON\NeosCliTools\Service\CRService
+     * @var CRService
      */
     protected $cr;
 
@@ -43,9 +38,9 @@ class PageCommandController extends CommandController
      *
      * @param string $workspace workspace to use, e.g. 'user-admin', defaults to 'live'
      *
-     * @throws \Exception
+     * @throws Exception
      */
-    public function infoCommand($workspace = 'live')
+    public function infoCommand(string $workspace = 'live')
     {
         $this->cr->setup($workspace);
 
@@ -55,7 +50,8 @@ class PageCommandController extends CommandController
                 ['Workspace Name', $this->cr->workspaceName],
                 ['Site node name', $this->cr->currentSite->getNodeName()],
             ],
-            [ 'Key', 'Value']);
+            [ 'Key', 'Value']
+        );
     }
 
     /**
@@ -66,17 +62,17 @@ class PageCommandController extends CommandController
      * @param string $workspace workspace to use, e.g. 'user-admin', defaults to 'live'
      *
      */
-    public function listCommand($depth=1, $path = '', $workspace = 'live')
+    public function listCommand(int $depth = 1, string $path = '', string $workspace = 'live')
     {
         try {
             $this->cr->setup($workspace);
             $rootNode = $this->cr->getNodeForPath($path);
             if (!$rootNode) {
-                throw new \Exception(sprintf('Could not find any node on path "%s"', $path));
+                throw new Exception(sprintf('Could not find any node on path "%s"', $path));
             }
             $printer = new NeosDocumentTreePrinter($rootNode, $depth);
             $printer->printTree($this->output);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->outputLine('ERROR: %s', [$e->getMessage()]);
         }
     }
@@ -90,9 +86,9 @@ class PageCommandController extends CommandController
      * @param int $limit limit
      * @param string $workspace workspace to use, e.g. 'user-admin', defaults to 'live'
      *
-     * @throws \Neos\Flow\Mvc\Exception\StopActionException
+     * @throws StopCommandException
      */
-    public function removeCommand($path = '', $url = '', $limit = 0, $workspace = 'live')
+    public function removeCommand(string $path = '', string $url = '', int $limit = 0, string $workspace = 'live')
     {
         try {
             $this->cr->setup($workspace);
@@ -104,7 +100,7 @@ class PageCommandController extends CommandController
             }
 
             if (!$rootNode) {
-                throw new \Exception(sprintf('Could not find any node on path "%s"', $path));
+                throw new Exception(sprintf('Could not find any node on path "%s"', $path));
             }
             $walker = new NeosDocumentWalker($rootNode);
 
@@ -119,8 +115,8 @@ class PageCommandController extends CommandController
                 ['Deleted Pages']);
             $this->quit(count($nodesToDelete) > 0 ? 0 : 1);
 
-        } catch (\Exception $e) {
-            if ($e instanceof \Neos\Flow\Mvc\Exception\StopActionException) { return; }
+        } catch (Exception $e) {
+            if ($e instanceof StopActionException) { return; }
             $this->outputLine('ERROR: %s', [$e->getMessage()]);
             $this->quit(1);
         }
@@ -131,14 +127,14 @@ class PageCommandController extends CommandController
      *
      * @param string $workspace workspace to use, e.g. 'user-admin', defaults to 'live'
      *
-     * @throws \Neos\Flow\Mvc\Exception\StopActionException
+     * @throws StopCommandException
      */
-    public function publishCommand($workspace = 'live')
+    public function publishCommand(string $workspace = 'live')
     {
         try {
             $this->cr->setup($workspace);
             $this->cr->publish();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->outputLine('ERROR: %s', [$e->getMessage()]);
             $this->quit(1);
         }
@@ -150,14 +146,13 @@ class PageCommandController extends CommandController
      * @param string $url URL to resolve
      * @param string $workspace workspace to use, e.g. 'user-admin', defaults to 'live'
      */
-    public function resolveURLCommand($url, $workspace = 'live')
+    public function resolveURLCommand(string $url, string $workspace = 'live')
     {
         try {
             $this->cr->setup($workspace);
-            /** @var NodeInterface $document */
             $document = $this->cr->getNodeForPath('');
             $this->outputLine('%s', [$this->cr->getNodePathForURL($document, $url)]);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->outputLine('ERROR: %s', [$e->getMessage()]);
         }
     }
@@ -168,11 +163,11 @@ class PageCommandController extends CommandController
      * @param string $parentUrl parent of the new page to be created (must exist), e.g. /news
      * @param string $name name of the node, will also be used for the URL segment
      * @param string $type node type, defaults to Neos.Neos.NodeTypes:Page
-     * @param string $properties node properties, as JSON, e.g. '{"title":"My Fancy Title"}'
+     * @param string|null $properties node properties, as JSON, e.g. '{"title":"My Fancy Title"}'
      * @param string $workspace workspace to use, e.g. 'user-admin', defaults to 'live'
      * @param boolean $overwriteExisting whether to overwrite an existing node for that path instead of creating a new one with path segment "node-..."
      */
-    public function createCommand($parentUrl, $name, $type = 'Neos.NodeTypes:Page', $properties = null, $workspace = 'live', $overwriteExisting = false)
+    public function createCommand(string $parentUrl, string $name, string $type = 'Neos.NodeTypes:Page', string $properties = null, string $workspace = 'live', bool $overwriteExisting = false)
     {
         try {
             $this->cr->setup($workspace);
@@ -192,10 +187,8 @@ class PageCommandController extends CommandController
             if ($properties) {
                 $this->cr->setNodeProperties($node, $properties);
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->outputLine('ERROR: %s', [$e->getMessage()]);
         }
-
     }
-
 }

--- a/Classes/Service/CRService.php
+++ b/Classes/Service/CRService.php
@@ -6,11 +6,11 @@ use DateTime;
 use Exception;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraintFactory;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
 use Neos\ContentRepository\Domain\Service\NodeServiceInterface;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\Flow\Annotations as Flow;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Media\Domain\Model\Image;
 use Neos\Media\Domain\Model\ImageInterface;
@@ -65,7 +65,7 @@ class CRService
      */
     public $context;
 
-    /** @var NodeInterface */
+    /** @var TraversableNodeInterface */
     public $rootNode;
 
     /**
@@ -108,14 +108,14 @@ class CRService
     }
 
     /**
-     * @param NodeInterface $document
+     * @param TraversableNodeInterface $document
      * @param $url
      *
      * @return string
      *
      * @throws Exception
      */
-    public function getNodePathForURL(NodeInterface $document, $url): string
+    public function getNodePathForURL(TraversableNodeInterface $document, $url): string
     {
         $parts = explode('/', $url);
         foreach ($parts as $segment) {
@@ -127,16 +127,16 @@ class CRService
     }
 
     /**
-     * @param NodeInterface $document
+     * @param TraversableNodeInterface $document
      * @param $pathSegment
      *
-     * @return NodeInterface
+     * @return TraversableNodeInterface
      * @throws Exception
      */
-    private function getChildDocumentByURIPathSegment(NodeInterface $document, $pathSegment): NodeInterface
+    private function getChildDocumentByURIPathSegment(TraversableNodeInterface $document, $pathSegment): TraversableNodeInterface
     {
         $found = array_filter($document->findChildNodes($this->nodeTypeConstraintFactory->parseFilterString('Neos.Neos:Document'))->toArray(),
-            function (NodeInterface $document) use ($pathSegment ){
+            function (TraversableNodeInterface $document) use ($pathSegment ){
                 return $document->getProperty('uriPathSegment') === $pathSegment;
             }
         );
@@ -171,12 +171,12 @@ class CRService
     /**
      * Sets the node properties
      *
-     * @param NodeInterface $node
+     * @param TraversableNodeInterface $node
      * @param string $propertiesJSON JSON string of node properties
      *
      * @throws Exception
      */
-    public function setNodeProperties(NodeInterface $node, string $propertiesJSON)
+    public function setNodeProperties(TraversableNodeInterface $node, string $propertiesJSON)
     {
         $data = json_decode($propertiesJSON, true);
 
@@ -195,10 +195,10 @@ class CRService
      *
      * @param string $url URL of the node, e.g. '/news/my-news'
      *
-     * @return NodeInterface
+     * @return TraversableNodeInterface
      * @throws Exception
      */
-    public function getNodeForURL(string $url): NodeInterface
+    public function getNodeForURL(string $url): TraversableNodeInterface
     {
         return $this->context->getNode($this->getNodePathForURL($this->rootNode, $url));
     }
@@ -208,10 +208,10 @@ class CRService
      *
      * @param string $path relative path of the page
      *
-     * @return NodeInterface
+     * @return TraversableNodeInterface
      * @throws Exception
      */
-    public function getNodeForPath(string $path): NodeInterface
+    public function getNodeForPath(string $path): TraversableNodeInterface
     {
         return $this->context->getNode($this->sitePath . $path);
     }
@@ -231,12 +231,12 @@ class CRService
     }
 
     /**
-     * @param NodeInterface $parentNode
+     * @param TraversableNodeInterface $parentNode
      * @param string|null $idealNodeName
      *
      * @return string
      */
-    public function generateUniqNodeName(NodeInterface $parentNode, string $idealNodeName = null): string
+    public function generateUniqNodeName(TraversableNodeInterface $parentNode, string $idealNodeName = null): string
     {
         return $this->nodeService->generateUniqueNodeName($parentNode->findNodePath(), $idealNodeName);
     }
@@ -257,14 +257,14 @@ class CRService
     /**
      * Map a String Value to the corresponding Neos Object
      *
-     * @param $node NodeInterface
+     * @param $node TraversableNodeInterface
      * @param $propertyName string
      * @param $stringInput string
      *
      * @return mixed
      * @throws Exception
      */
-    protected function propertyMapper(NodeInterface $node, string $propertyName, string $stringInput)
+    protected function propertyMapper(TraversableNodeInterface $node, string $propertyName, string $stringInput)
     {
 
         if ($stringInput === 'NULL') {

--- a/Classes/Utility/NeosDocumentTreePrinter.php
+++ b/Classes/Utility/NeosDocumentTreePrinter.php
@@ -1,13 +1,8 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: remuslazar
- * Date: 02.05.18
- * Time: 22:12
- */
 
 namespace CRON\NeosCliTools\Utility;
 
+use Neos\ContentRepository\Exception\NodeException;
 use Neos\Flow\Cli\ConsoleOutput;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 
@@ -33,9 +28,9 @@ class NeosDocumentTreePrinter
      *
      * @param array $currentURLPathPrefix
      *
-     * @throws \Neos\ContentRepository\Exception\NodeException
+     * @throws NodeException
      */
-    private function printDocument(NodeInterface $document, $currentDepth = 0, array $currentURLPathPrefix = [])
+    private function printDocument(NodeInterface $document, int $currentDepth = 0, array $currentURLPathPrefix = [])
     {
         $urlPathPrefix = array_merge($currentURLPathPrefix, [$document->getProperty('uriPathSegment')]);
         $url = join('/', $urlPathPrefix);
@@ -47,7 +42,6 @@ class NeosDocumentTreePrinter
             $this->trimPath($document->getPath()),
         ], $currentDepth * 0);
 
-//        \Neos\Flow\var_dump($document);
         if ($currentDepth < $this->maxDepth) {
             $childDocuments = $document->getChildNodes('Neos.Neos:Document');
             foreach ($childDocuments as $childDocument) {
@@ -65,9 +59,9 @@ class NeosDocumentTreePrinter
      *
      * @param array $currentURLPathPrefix
      *
-     * @throws \Neos\ContentRepository\Exception\NodeException
+     * @throws NodeException
      */
-    private function buildDocumentTreeRecursive(NodeInterface $document, $currentDepth = 0, array $currentURLPathPrefix = [])
+    private function buildDocumentTreeRecursive(NodeInterface $document, int $currentDepth = 0, array $currentURLPathPrefix = [])
     {
         $urlPathPrefix = array_merge($currentURLPathPrefix, [$document->getProperty('uriPathSegment')]);
         $url = join('/', $urlPathPrefix);
@@ -93,9 +87,9 @@ class NeosDocumentTreePrinter
      *
      * @param bool $asTable
      *
-     * @throws \Neos\ContentRepository\Exception\NodeException
+     * @throws NodeException
      */
-    public function printTree(ConsoleOutput $output, $asTable = true)
+    public function printTree(ConsoleOutput $output, bool $asTable = true)
     {
         $this->consoleOutput = $output;
         if ($asTable) {

--- a/Classes/Utility/NeosDocumentTreePrinter.php
+++ b/Classes/Utility/NeosDocumentTreePrinter.php
@@ -2,6 +2,7 @@
 
 namespace CRON\NeosCliTools\Utility;
 
+use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraintFactory;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\ContentRepository\Exception\NodeException;

--- a/Classes/Utility/NeosDocumentTreePrinter.php
+++ b/Classes/Utility/NeosDocumentTreePrinter.php
@@ -2,6 +2,7 @@
 
 namespace CRON\NeosCliTools\Utility;
 
+use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraintFactory;
 use Neos\ContentRepository\Exception\NodeException;
 use Neos\Flow\Cli\ConsoleOutput;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
@@ -13,13 +14,19 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
  */
 class NeosDocumentTreePrinter
 {
+    /**
+     * @Flow\Inject
+     * @var NodeTypeConstraintFactory
+     */
+    protected $nodeTypeConstraintFactory;
+
     public function __construct(NodeInterface $node, $maxDepth = 0) {
         $this->maxDepth = $maxDepth;
         $this->rootNode = $node;
     }
 
     private function trimPath($input) {
-        return str_replace($this->rootNode->getPath(), '', $input);
+        return str_replace($this->rootNode->findNodePath(), '', $input);
     }
 
     /**
@@ -39,11 +46,11 @@ class NeosDocumentTreePrinter
             str_replace('home', '', $url),
             $document->getProperty('title'),
             $document->getNodeType()->getName(),
-            $this->trimPath($document->getPath()),
+            $this->trimPath($document->findNodePath()),
         ], $currentDepth * 0);
 
         if ($currentDepth < $this->maxDepth) {
-            $childDocuments = $document->getChildNodes('Neos.Neos:Document');
+            $childDocuments = $document->findChildNodes($this->nodeTypeConstraintFactory->parseFilterString('Neos.Neos:Document'));
             foreach ($childDocuments as $childDocument) {
                 $this->printDocument($childDocument, $currentDepth + 1, $urlPathPrefix);
             }
@@ -70,11 +77,11 @@ class NeosDocumentTreePrinter
             str_replace('home', '', $url),
             $document->getProperty('title'),
             $document->getNodeType()->getName(),
-            $this->trimPath($document->getPath()),
+            $this->trimPath($document->findNodePath()),
         ];
 
         if ($currentDepth < $this->maxDepth) {
-            $childDocuments = $document->getChildNodes('Neos.Neos:Document');
+            $childDocuments = $document->findChildNodes($this->nodeTypeConstraintFactory->parseFilterString('Neos.Neos:Document'));
             foreach ($childDocuments as $childDocument) {
                 $this->buildDocumentTreeRecursive($childDocument, $currentDepth + 1, $urlPathPrefix);
             }

--- a/Classes/Utility/NeosDocumentTreePrinter.php
+++ b/Classes/Utility/NeosDocumentTreePrinter.php
@@ -3,13 +3,13 @@
 namespace CRON\NeosCliTools\Utility;
 
 use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraintFactory;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\ContentRepository\Exception\NodeException;
 use Neos\Flow\Cli\ConsoleOutput;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
 
 /**
  * @property int maxDepth
- * @property NodeInterface rootNode
+ * @property TraversableNodeInterface rootNode
  * @property ConsoleOutput consoleOutput
  */
 class NeosDocumentTreePrinter
@@ -20,7 +20,7 @@ class NeosDocumentTreePrinter
      */
     protected $nodeTypeConstraintFactory;
 
-    public function __construct(NodeInterface $node, $maxDepth = 0) {
+    public function __construct(TraversableNodeInterface $node, $maxDepth = 0) {
         $this->maxDepth = $maxDepth;
         $this->rootNode = $node;
     }
@@ -30,14 +30,14 @@ class NeosDocumentTreePrinter
     }
 
     /**
-     * @param NodeInterface $document
+     * @param TraversableNodeInterface $document
      * @param int $currentDepth
      *
      * @param array $currentURLPathPrefix
      *
      * @throws NodeException
      */
-    private function printDocument(NodeInterface $document, int $currentDepth = 0, array $currentURLPathPrefix = [])
+    private function printDocument(TraversableNodeInterface $document, int $currentDepth = 0, array $currentURLPathPrefix = [])
     {
         $urlPathPrefix = array_merge($currentURLPathPrefix, [$document->getProperty('uriPathSegment')]);
         $url = join('/', $urlPathPrefix);
@@ -61,14 +61,14 @@ class NeosDocumentTreePrinter
     private $documentTree = [];
 
     /**
-     * @param NodeInterface $document
+     * @param TraversableNodeInterface $document
      * @param int $currentDepth
      *
      * @param array $currentURLPathPrefix
      *
      * @throws NodeException
      */
-    private function buildDocumentTreeRecursive(NodeInterface $document, int $currentDepth = 0, array $currentURLPathPrefix = [])
+    private function buildDocumentTreeRecursive(TraversableNodeInterface $document, int $currentDepth = 0, array $currentURLPathPrefix = [])
     {
         $urlPathPrefix = array_merge($currentURLPathPrefix, [$document->getProperty('uriPathSegment')]);
         $url = join('/', $urlPathPrefix);

--- a/Classes/Utility/NeosDocumentWalker.php
+++ b/Classes/Utility/NeosDocumentWalker.php
@@ -1,6 +1,7 @@
 <?php
 namespace CRON\NeosCliTools\Utility;
 
+use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraintFactory;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 

--- a/Classes/Utility/NeosDocumentWalker.php
+++ b/Classes/Utility/NeosDocumentWalker.php
@@ -2,6 +2,7 @@
 namespace CRON\NeosCliTools\Utility;
 
 use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraintFactory;
 
 /**
  * @property int limit
@@ -10,6 +11,12 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
  */
 class NeosDocumentWalker
 {
+    /**
+     * @Flow\Inject
+     * @var NodeTypeConstraintFactory
+     */
+    protected $nodeTypeConstraintFactory;
+
     public function __construct(NodeInterface $rootNode)
     {
         $this->rootNode = $rootNode;
@@ -17,7 +24,7 @@ class NeosDocumentWalker
 
     private function walk(NodeInterface $node) {
 
-        foreach ($node->getChildNodes('Neos.Neos:Document') as $childNode) {
+        foreach ($node->findChildNodes($this->nodeTypeConstraintFactory->parseFilterString('Neos.Neos:Document')) as $childNode) {
             if ($this->limit && count($this->nodes) >= $this->limit) {
                 return;
             }

--- a/Classes/Utility/NeosDocumentWalker.php
+++ b/Classes/Utility/NeosDocumentWalker.php
@@ -1,13 +1,13 @@
 <?php
 namespace CRON\NeosCliTools\Utility;
 
-use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraintFactory;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 
 /**
  * @property int limit
- * @property NodeInterface rootNode
- * @property NodeInterface[] nodes
+ * @property TraversableNodeInterface rootNode
+ * @property TraversableNodeInterface[] nodes
  */
 class NeosDocumentWalker
 {
@@ -17,12 +17,12 @@ class NeosDocumentWalker
      */
     protected $nodeTypeConstraintFactory;
 
-    public function __construct(NodeInterface $rootNode)
+    public function __construct(TraversableNodeInterface $rootNode)
     {
         $this->rootNode = $rootNode;
     }
 
-    private function walk(NodeInterface $node) {
+    private function walk(TraversableNodeInterface $node) {
 
         foreach ($node->findChildNodes($this->nodeTypeConstraintFactory->parseFilterString('Neos.Neos:Document')) as $childNode) {
             if ($this->limit && count($this->nodes) >= $this->limit) {
@@ -40,7 +40,7 @@ class NeosDocumentWalker
      *
      * @param int $limit
      *
-     * @return array|NodeInterface[]
+     * @return array|TraversableNodeInterface[]
      */
     public function getNodes(int $limit = 0): array
     {

--- a/Classes/Utility/NeosDocumentWalker.php
+++ b/Classes/Utility/NeosDocumentWalker.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: remuslazar
- * Date: 02.05.18
- * Time: 23:45
- */
-
 namespace CRON\NeosCliTools\Utility;
 
 use Neos\ContentRepository\Domain\Model\NodeInterface;
@@ -42,7 +35,8 @@ class NeosDocumentWalker
      *
      * @return array|NodeInterface[]
      */
-    public function getNodes($limit=0) {
+    public function getNodes(int $limit = 0): array
+    {
         $this->limit = $limit;
         $this->nodes = [];
         $this->walk($this->rootNode);

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
 	"name": "cron/neos-cli-tools",
 	"type": "neos-package",
 	"require": {
-		"neos/neos": "*"
+		"neos/neos": "^4.3 || ^5.0",
+    "neos/flow": "^5.3 || ^6.0"
 	},
 	"license": "proprietary",
 	"description": "CLI Content Repository related utilities (previously part of CRLib)",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "cron/neos-cli-tools",
 	"type": "neos-package",
 	"require": {
-		"neos/neos": "~4.0"
+		"neos/neos": "*"
 	},
 	"license": "proprietary",
 	"description": "CLI Content Repository related utilities (previously part of CRLib)",


### PR DESCRIPTION
This PR makes this package compatible for Neos ^5.0 (Flow ^6.0).

Most importantly this PR replaces the usages of the deprecated NodeInterface methods (since 4.3) with the new TraversableNodeInterface.

This PR also fixes most of the (weak) warnings.