### PR TITLE
DAVPTA-851 Extend Functionality

### DIFF
--- a/Classes/Service/CRService.php
+++ b/Classes/Service/CRService.php
@@ -4,6 +4,7 @@ namespace CRON\NeosCliTools\Service;
 
 use DateTime;
 use Exception;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraintFactory;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
@@ -214,6 +215,16 @@ class CRService
     public function getNodeForPath(string $path): TraversableNodeInterface
     {
         return $this->context->getNode($this->sitePath . $path);
+    }
+
+    /**
+     * @param $identifier
+     *
+     * @return TraversableNodeInterface|null
+     */
+    public function getNodeForIdentifier($identifier): ?TraversableNodeInterface
+    {
+        return $this->context->getNodeByIdentifier($identifier);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
   "type": "neos-package",
   "require": {
     "neos/neos": "^4.3 || ^5.0 || ^7.0",
-    "neos/flow": "^5.3 || ^6.0 || ^7.0"
+    "neos/flow": "^5.3 || ^6.0 || ^7.0",
+    "cocur/slugify": "^4.0"
   },
   "license": "proprietary",
   "description": "CLI Content Repository related utilities (previously part of CRLib)",


### PR DESCRIPTION
This PR extends the functionality of the commands by
- `flow page:striptagsfromtitle`: strips tage from a page node title and optionally also updates the URI path segment
- `flow page:update`:  updates properties, name and hidden state of a page
- `flow content:update`:  updates properties, name and hidden state of a content element

The use case of having to edit node properties or hiding nodes has appeared a few times already, so these changes will allow doing it via command line instead of via SQL in the database.
Events like `nodeUpdated` will also be emitted automatically, which triggers cache flushes and ElasticSearch indexing.

# References
https://cron-eu.atlassian.net/browse/DAVPTA-851